### PR TITLE
Fix module path

### DIFF
--- a/flat_test.go
+++ b/flat_test.go
@@ -3,9 +3,9 @@ package flat_test
 import (
 	"encoding/json"
 	"errors"
-	"flat"
 	"testing"
 
+	"github.com/millerhederi/flat"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module flat
+module github.com/millerhederi/flat
 
 go 1.19
 


### PR DESCRIPTION
Module path was previously `flat` for local development. Now that we're pushing to Github, fix with the appropriate module path so that the module can be imported into pkg.go.dev.